### PR TITLE
Make ForeignKeys Cascade delete

### DIFF
--- a/FasTnT.Application/Store/Migrations/20220119082759_CascadeForeignKeys.Designer.cs
+++ b/FasTnT.Application/Store/Migrations/20220119082759_CascadeForeignKeys.Designer.cs
@@ -4,6 +4,7 @@ using FasTnT.Infrastructure.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FasTnT.Application.Migrations
 {
     [DbContext(typeof(EpcisContext))]
-    partial class EpcisContextModelSnapshot : ModelSnapshot
+    [Migration("20220119082759_CascadeForeignKeys")]
+    partial class CascadeForeignKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FasTnT.Application/Store/Migrations/20220119082759_CascadeForeignKeys.cs
+++ b/FasTnT.Application/Store/Migrations/20220119082759_CascadeForeignKeys.cs
@@ -1,0 +1,131 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FasTnT.Application.Migrations
+{
+    public partial class CascadeForeignKeys : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Event_Request_RequestId",
+                schema: "Epcis",
+                table: "Event");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MasterDataChildren_MasterData_MasterDataRequestId_MasterDataType_MasterDataId",
+                schema: "Cbv",
+                table: "MasterDataChildren");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Subscription_SubscriptionSchedule_ScheduleId",
+                schema: "Subscription",
+                table: "Subscription");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SubscriptionCallback_Request_RequestId",
+                schema: "Epcis",
+                table: "SubscriptionCallback");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Event_Request_RequestId",
+                schema: "Epcis",
+                table: "Event",
+                column: "RequestId",
+                principalSchema: "Epcis",
+                principalTable: "Request",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MasterDataChildren_MasterData_MasterDataRequestId_MasterDataType_MasterDataId",
+                schema: "Cbv",
+                table: "MasterDataChildren",
+                columns: new[] { "MasterDataRequestId", "MasterDataType", "MasterDataId" },
+                principalSchema: "Cbv",
+                principalTable: "MasterData",
+                principalColumns: new[] { "RequestId", "Type", "Id" },
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Subscription_SubscriptionSchedule_ScheduleId",
+                schema: "Subscription",
+                table: "Subscription",
+                column: "ScheduleId",
+                principalSchema: "Subscription",
+                principalTable: "SubscriptionSchedule",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SubscriptionCallback_Request_RequestId",
+                schema: "Epcis",
+                table: "SubscriptionCallback",
+                column: "RequestId",
+                principalSchema: "Epcis",
+                principalTable: "Request",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Event_Request_RequestId",
+                schema: "Epcis",
+                table: "Event");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MasterDataChildren_MasterData_MasterDataRequestId_MasterDataType_MasterDataId",
+                schema: "Cbv",
+                table: "MasterDataChildren");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Subscription_SubscriptionSchedule_ScheduleId",
+                schema: "Subscription",
+                table: "Subscription");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_SubscriptionCallback_Request_RequestId",
+                schema: "Epcis",
+                table: "SubscriptionCallback");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Event_Request_RequestId",
+                schema: "Epcis",
+                table: "Event",
+                column: "RequestId",
+                principalSchema: "Epcis",
+                principalTable: "Request",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MasterDataChildren_MasterData_MasterDataRequestId_MasterDataType_MasterDataId",
+                schema: "Cbv",
+                table: "MasterDataChildren",
+                columns: new[] { "MasterDataRequestId", "MasterDataType", "MasterDataId" },
+                principalSchema: "Cbv",
+                principalTable: "MasterData",
+                principalColumns: new[] { "RequestId", "Type", "Id" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Subscription_SubscriptionSchedule_ScheduleId",
+                schema: "Subscription",
+                table: "Subscription",
+                column: "ScheduleId",
+                principalSchema: "Subscription",
+                principalTable: "SubscriptionSchedule",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SubscriptionCallback_Request_RequestId",
+                schema: "Epcis",
+                table: "SubscriptionCallback",
+                column: "RequestId",
+                principalSchema: "Epcis",
+                principalTable: "Request",
+                principalColumn: "Id");
+        }
+    }
+}


### PR DESCRIPTION
Allows to delete a Header record and all the associated Events (and other tables) in a single query.
It makes the cleanup of data much easier