### PR TITLE
Fix query results count

### DIFF
--- a/FasTnT.Application/Services/Queries/SimpleEventQuery.cs
+++ b/FasTnT.Application/Services/Queries/SimpleEventQuery.cs
@@ -19,7 +19,7 @@ public class SimpleEventQuery : IEpcisQuery
     const string Comparison = "(GE|GT|LE|LT)";
 
     private readonly EpcisContext _context;
-    private int? _maxEventCount = default;
+    private int? _maxEventCount = default, _eventCountLimit = Constants.MaxEventsReturnedInQuery + 1;
     private OrderDirection _orderDirection = OrderDirection.Ascending;
     private Expression<Func<Event, object>> _orderExpression = e => e.CaptureTime;
 
@@ -33,7 +33,8 @@ public class SimpleEventQuery : IEpcisQuery
 
     public async Task<PollResponse> HandleAsync(IEnumerable<QueryParameter> parameters, CancellationToken cancellationToken)
     {
-        var query = _context.Events.AsNoTracking();
+        var query = _context.Events
+            .AsNoTracking();
 
         foreach (var parameter in parameters)
         {
@@ -49,9 +50,10 @@ public class SimpleEventQuery : IEpcisQuery
 
         try
         {
-            var eventIds = await ApplyOrderBy(query)
+            var eventIds = await ApplyOrderByLimit(query)
                 .Select(evt => evt.Id)
-                .ToListAsync(cancellationToken);
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
 
             if (_maxEventCount.HasValue && eventIds.Count > _maxEventCount || eventIds.Count > Constants.MaxEventsReturnedInQuery)
             {
@@ -69,9 +71,9 @@ public class SimpleEventQuery : IEpcisQuery
                 .Include(x => x.Transactions)
                 .Where(evt => eventIds.Contains(evt.Id));
 
-            var result = await ApplyOrderBy(query).ToListAsync(cancellationToken);
+            var result = await query.ToListAsync(cancellationToken);
 
-            return new PollEventResponse(Name, result);
+            return new PollEventResponse(Name, ApplyOrderByLimit(result.AsQueryable()).ToList());
         }
         catch (InvalidOperationException ex) when (ex.InnerException is FormatException)
         {
@@ -87,11 +89,15 @@ public class SimpleEventQuery : IEpcisQuery
         }
     }
 
-    private IQueryable<Event> ApplyOrderBy(IQueryable<Event> query)
+    private IQueryable<Event> ApplyOrderByLimit(IQueryable<Event> query)
     {
+        var limit = _maxEventCount.HasValue 
+            ? _maxEventCount.Value + 1
+            : _eventCountLimit.Value;    
+
         return _orderDirection == OrderDirection.Ascending
-            ? query.OrderBy(_orderExpression)
-            : query.OrderByDescending(_orderExpression);
+            ? query.OrderBy(_orderExpression).Take(limit)
+            : query.OrderByDescending(_orderExpression).Take(limit);
     }
 
     private IQueryable<Event> ApplyParameter(QueryParameter param, IQueryable<Event> query)
@@ -103,8 +109,8 @@ public class SimpleEventQuery : IEpcisQuery
             "orderDirection" => ParseOrderDirection(param, query),
             // Simple filters
             "eventType" => query.Where(x => param.Values.Select(x => Enum.Parse<EventType>(x, true)).Contains(x.Type)),
-            "eventCountLimit" => query.Take(param.GetIntValue()),
-            "maxEventCount" => ParseMaxEventCount(param, query),
+            "eventCountLimit" => ParseLimitEventCount(param, query, ref _eventCountLimit),
+            "maxEventCount" => ParseLimitEventCount(param, query, ref _maxEventCount),
             "GE_eventTime" => query.Where(x => x.EventTime >= param.GetDate()),
             "LT_eventTime" => query.Where(x => x.EventTime < param.GetDate()),
             "GE_recordTime" => query.Where(x => x.Request.CaptureDate >= param.GetDate()),
@@ -183,11 +189,11 @@ public class SimpleEventQuery : IEpcisQuery
     private static IQueryable<Event> ApplyCustomFieldParameter(string[] values, IQueryable<Event> query, FieldType type, bool inner, string name, string ns)
         => query.Where(x => x.CustomFields.Any(f => f.Type == type && f.Parent == null == !inner && values.Contains(f.TextValue) && f.Name == name && f.Namespace == ns));
 
-    private IQueryable<Event> ParseMaxEventCount(QueryParameter param, IQueryable<Event> query)
+    private static IQueryable<Event> ParseLimitEventCount(QueryParameter param, IQueryable<Event> query, ref int? destination)
     {
-        _maxEventCount = param.GetIntValue();
+        destination = param.GetIntValue();
 
-        return query.Take(1 + _maxEventCount.Value);
+        return query;
     }
 
     private static IQueryable<Event> ApplyComparison(QueryParameter param, IQueryable<Event> query, FieldType type, string ns, string name, bool inner)

--- a/FasTnT.Application/Services/Queries/SimpleEventQuery.cs
+++ b/FasTnT.Application/Services/Queries/SimpleEventQuery.cs
@@ -33,8 +33,7 @@ public class SimpleEventQuery : IEpcisQuery
 
     public async Task<PollResponse> HandleAsync(IEnumerable<QueryParameter> parameters, CancellationToken cancellationToken)
     {
-        var query = _context.Events
-            .AsNoTracking();
+        var query = _context.Events.AsNoTracking();
 
         foreach (var parameter in parameters)
         {

--- a/FasTnT.Application/Store/Configuration/EpcisModelConfiguration.cs
+++ b/FasTnT.Application/Store/Configuration/EpcisModelConfiguration.cs
@@ -126,7 +126,7 @@ internal static class EpcisModelConfiguration
         var evt = modelBuilder.Entity<Event>();
         evt.ToTable(nameof(Event), nameof(EpcisSchema.Epcis));
         evt.HasKey(x => x.Id);
-        evt.Property(x => x.Id).IsRequired(true).UseIdentityColumn(1, 1);
+        evt.Property(x => x.Id).IsRequired(true).UseIdentityColumn(1, 1).HasColumnType("bigint");
         evt.Property(x => x.EventTime).IsRequired(true);
         evt.Property(x => x.Type).IsRequired(true).HasConversion<short>();
         evt.Property(x => x.EventTimeZoneOffset).IsRequired(true).HasConversion(x => x.Value, x => new TimeZoneOffset { Value = x });
@@ -150,7 +150,7 @@ internal static class EpcisModelConfiguration
         var epc = modelBuilder.Entity<Epc>();
         epc.ToTable(nameof(Epc), nameof(EpcisSchema.Epcis));
         epc.HasKey("EventId", nameof(Epc.Type), nameof(Epc.Id));
-        epc.Property<long>("EventId");
+        epc.Property<long>("EventId").HasColumnType("bigint");
         epc.Property(x => x.Type).IsRequired(true).HasConversion<short>();
         epc.Property(x => x.Id).HasMaxLength(256).IsRequired(true);
         epc.Property(x => x.IsQuantity).IsRequired(true).HasDefaultValue(false);
@@ -161,19 +161,19 @@ internal static class EpcisModelConfiguration
         var eventId = modelBuilder.Entity<CorrectiveEventId>();
         eventId.ToTable(nameof(CorrectiveEventId), nameof(EpcisSchema.Epcis));
         eventId.HasKey("EventId", nameof(CorrectiveEventId.CorrectiveId));
-        eventId.Property<long>("EventId");
+        eventId.Property<long>("EventId").HasColumnType("bigint");
         eventId.Property(x => x.CorrectiveId).IsRequired(true).HasMaxLength(256);
 
         var source = modelBuilder.Entity<Source>();
         source.ToTable(nameof(Source), nameof(EpcisSchema.Epcis));
-        source.Property<long>("EventId");
+        source.Property<long>("EventId").HasColumnType("bigint");
         source.HasKey("EventId", nameof(Source.Type), nameof(Source.Id));
         source.Property(x => x.Type).IsRequired(true);
         source.Property(x => x.Id).HasMaxLength(256).IsRequired(true);
 
         var dest = modelBuilder.Entity<Destination>();
         dest.ToTable(nameof(Destination), nameof(EpcisSchema.Epcis));
-        dest.Property<long>("EventId");
+        dest.Property<long>("EventId").HasColumnType("bigint");
         dest.HasKey("EventId", nameof(Destination.Type), nameof(Destination.Id));
         dest.Property(x => x.Type).IsRequired(true);
         dest.Property(x => x.Id).HasMaxLength(256).IsRequired(true);
@@ -181,7 +181,7 @@ internal static class EpcisModelConfiguration
         var bizTrans = modelBuilder.Entity<BusinessTransaction>();
         bizTrans.ToTable(nameof(BusinessTransaction), nameof(EpcisSchema.Epcis));
         bizTrans.HasKey("EventId", nameof(BusinessTransaction.Type), nameof(BusinessTransaction.Id));
-        bizTrans.Property<long>("EventId");
+        bizTrans.Property<long>("EventId").HasColumnType("bigint");
         bizTrans.Property(x => x.Type).IsRequired(true);
         bizTrans.Property(x => x.Id).HasMaxLength(256).IsRequired(true);
         bizTrans.HasOne(x => x.Event).WithMany(x => x.Transactions).HasForeignKey("EventId").OnDelete(DeleteBehavior.Cascade);
@@ -189,7 +189,7 @@ internal static class EpcisModelConfiguration
         var customField = modelBuilder.Entity<CustomField>();
         customField.ToTable(nameof(CustomField), nameof(EpcisSchema.Epcis));
         customField.Property<int>("FieldId").IsRequired(true).HasValueGenerator<IncrementGenerator>();
-        customField.Property<long>("EventId");
+        customField.Property<long>("EventId").HasColumnType("bigint");
         customField.Property<int?>("ParentId");
         customField.HasKey("EventId", "FieldId");
         customField.Property(x => x.Type).IsRequired(true).HasConversion<short>();

--- a/FasTnT.Host/appsettings.Development.json
+++ b/FasTnT.Host/appsettings.Development.json
@@ -9,8 +9,5 @@
   },
   "Constants": {
     "MaxEventsReturnedInQuery": 1000
-  },
-  "ConnectionStrings": {
-    "FasTnT.Database": "Server=tcp:fastnt-dev-sql-server.database.windows.net,1433;Initial Catalog=fastnt-dev-sql-db;Persist Security Info=False;User ID=fastnt_admin;Password=F@sT&T_pwd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
   }
 }

--- a/FasTnT.Host/appsettings.Development.json
+++ b/FasTnT.Host/appsettings.Development.json
@@ -9,5 +9,8 @@
   },
   "Constants": {
     "MaxEventsReturnedInQuery": 1000
+  },
+  "ConnectionStrings": {
+    "FasTnT.Database": "Server=tcp:fastnt-dev-sql-server.database.windows.net,1433;Initial Catalog=fastnt-dev-sql-db;Persist Security Info=False;User ID=fastnt_admin;Password=F@sT&T_pwd;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
   }
 }

--- a/Tests/FasTnT.Application.Tests/Queries/WhenSimpleEventQueryReturnsLessThanMaxEventCountParameter.cs
+++ b/Tests/FasTnT.Application.Tests/Queries/WhenSimpleEventQueryReturnsLessThanMaxEventCountParameter.cs
@@ -1,0 +1,47 @@
+﻿using FasTnT.Application.Queries;
+using FasTnT.Application.Services;
+using FasTnT.Domain.Queries;
+using FasTnT.Infrastructure.Database;
+
+namespace FasTnT.Application.Tests.Queries
+{
+    [TestClass]
+    public class WhenSimpleEventQueryReturnsLessThanMaxEventCountParameter
+    {
+        public EpcisContext Context { get; set; }
+        public IEpcisQuery Query { get; set; }
+        public IList<QueryParameter> Parameters { get; set; }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            Context = Tests.Context.TestContext.GetContext("simpleEventQuery");
+            Query = new SimpleEventQuery(Context);
+
+            Context.Requests.Add(new Domain.Model.Request
+            {
+                Events = new[] {
+                    new Domain.Model.Event
+                    {
+                        Action = Domain.Enumerations.EventAction.Observe
+                    }
+                }.ToList(),
+                CaptureDate = DateTime.Now,
+                DocumentTime = DateTime.Now,
+                SchemaVersion = "1.2"
+            });
+            Context.SaveChanges();
+
+            Parameters = new[] { new QueryParameter("maxEventCount", new[] { "2" }) }.ToList();
+        }
+
+        [TestMethod]
+        public void ItShouldThrowAQueryTooLargeExceptionException()
+        {
+            var result = Query.HandleAsync(Parameters, default).Result;
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(result.EventList.Count, 1);
+        }
+    }
+}

--- a/Tests/FasTnT.Application.Tests/Queries/WhenSimpleEventQueryReturnsMoreThanMaxEventCountParameter.cs
+++ b/Tests/FasTnT.Application.Tests/Queries/WhenSimpleEventQueryReturnsMoreThanMaxEventCountParameter.cs
@@ -1,0 +1,63 @@
+﻿using FasTnT.Application.Queries;
+using FasTnT.Application.Services;
+using FasTnT.Domain.Exceptions;
+using FasTnT.Domain.Queries;
+using FasTnT.Infrastructure.Database;
+
+namespace FasTnT.Application.Tests.Queries
+{
+    [TestClass]
+    public class WhenSimpleEventQueryReturnsMoreThanMaxEventCountParameter
+    {
+        public EpcisContext Context { get; set; }
+        public IEpcisQuery Query { get; set; }
+        public IList<QueryParameter> Parameters { get; set; }
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            Context = Tests.Context.TestContext.GetContext("simpleEventQuery");
+            Query = new SimpleEventQuery(Context);
+
+            Context.Requests.Add(new Domain.Model.Request
+            {
+                Events = new[] {
+                    new Domain.Model.Event
+                    {
+                        Action = Domain.Enumerations.EventAction.Observe
+                    },
+                    new Domain.Model.Event
+                    {
+                        Action = Domain.Enumerations.EventAction.Observe
+                    }
+                }.ToList(),
+                CaptureDate = DateTime.Now,
+                DocumentTime = DateTime.Now,
+                SchemaVersion = "1.2"
+            });
+            Context.SaveChanges();
+
+            Parameters = new[] { new QueryParameter("maxEventCount", new[] { "1" }) }.ToList();
+        }
+
+        [TestMethod]
+        public void ItShouldThrowAQueryTooLargeExceptionException()
+        {
+            var catched = default(Exception);
+
+            try
+            {
+                Query.HandleAsync(Parameters, default).Wait();
+                Assert.IsFalse(true, "The query should fail");
+            }
+            catch(Exception ex)
+            {
+                catched = ex is AggregateException ? ex.InnerException : ex;
+            }
+
+            Assert.IsNotNull(catched);
+            Assert.IsInstanceOfType(catched, typeof(EpcisException));
+            Assert.AreEqual(((EpcisException)catched).ExceptionType, ExceptionType.QueryTooLargeException);
+        }
+    }
+}


### PR DESCRIPTION
EF Core applies filters in the order they are applied to the IQueryable...
This change sets the .Take(...) call at the very end to avoid limiting before further filtering.