### PR TITLE
Masterdata parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This is the list of planned and implemented 2.0 features in the repository:
 - Capture
   - [x] Capture list of Events
   - [x] Capture a single Event
-  - [ ] Capture CBV masterdata
+  - [x] Capture CBV masterdata
 - Queries:
   - [x] List events
   - [ ] Event pagination

--- a/src/FasTnT.Domain/Constants.cs
+++ b/src/FasTnT.Domain/Constants.cs
@@ -6,5 +6,5 @@ public sealed class Constants
 
     public int MaxEventsCapturePerCall { get; init; } = 500;
     public int MaxEventsReturnedInQuery { get; init; } = 20_000;
-    public string VendorVersion { get; init; } = "2.2.1";
+    public string VendorVersion { get; init; } = "2.2.3";
 }

--- a/src/FasTnT.Features.v2_0/Communication/Json/Parsers/JsonEpcisDocumentParser.cs
+++ b/src/FasTnT.Features.v2_0/Communication/Json/Parsers/JsonEpcisDocumentParser.cs
@@ -23,7 +23,7 @@ public static class JsonEpcisDocumentParser
                 case "schemaVersion":
                     request.SchemaVersion = property.Value.GetString(); break;
                 case "creationDate":
-                    request.DocumentTime = property.Value.GetDateTime(); break;
+                    request.DocumentTime = property.Value.GetDateTime().ToUniversalTime(); break;
                 case "epcisBody":
                     request.Events = ParseEvents(property.Value, extensions); break;
                 case "epcisHeader":

--- a/src/FasTnT.Features.v2_0/Communication/Json/Parsers/JsonEpcisDocumentParser.cs
+++ b/src/FasTnT.Features.v2_0/Communication/Json/Parsers/JsonEpcisDocumentParser.cs
@@ -1,4 +1,6 @@
-﻿using FasTnT.Domain.Model;
+﻿using FasTnT.Domain.Infrastructure.Exceptions;
+using FasTnT.Domain.Model;
+using FasTnT.Domain.Model.Events;
 using System.Text.Json;
 
 namespace FasTnT.Features.v2_0.Communication.Json.Parsers;
@@ -12,15 +14,49 @@ public static class JsonEpcisDocumentParser
             extensions = extensions.Merge(Namespaces.Parse(context));
         }
 
-        var schemaVersion = document.RootElement.GetProperty("schemaVersion").GetString();
-        var documentTime = document.RootElement.GetProperty("creationDate").GetDateTime();
-        var events = document.RootElement.GetProperty("epcisBody").GetProperty("eventList").EnumerateArray().Select(x => JsonEventParser.Create(x, extensions).Parse()).ToList();
+        var request = new Request();
 
-        return new Request
+        foreach(var property in document.RootElement.EnumerateObject())
         {
-            SchemaVersion = schemaVersion,
-            DocumentTime = documentTime,
-            Events = events
-        };
+            switch (property.Name)
+            {
+                case "schemaVersion":
+                    request.SchemaVersion = property.Value.GetString(); break;
+                case "creationDate":
+                    request.DocumentTime = property.Value.GetDateTime(); break;
+                case "epcisBody":
+                    request.Events = ParseEvents(property.Value, extensions); break;
+                case "epcisHeader":
+                    request.Masterdata = ParseMasterdata(property.Value, extensions); break;
+                case "type": break; // Must be EPCISDocument
+                case "@context": break; // Context is already parsed
+                default:
+                    throw new EpcisException(ExceptionType.ImplementationException, $"Unknown property type: '{property.Name}'"); break;
+            }
+        }
+        
+        return request;
+    }
+
+    public static List<Event> ParseEvents(JsonElement element, Namespaces extensions)
+    {
+        return element.GetProperty("eventList")
+            .EnumerateArray()
+            .Select(x => JsonEventParser.Create(x, extensions).Parse())
+            .ToList();
+    }
+
+    public static List<MasterData> ParseMasterdata(JsonElement element, Namespaces extensions)
+    {
+        var masterdataList = new List<MasterData>();
+
+        if(element.TryGetProperty("epcisMasterData", out var masterdata))
+        {
+            masterdataList.AddRange(masterdata.GetProperty("vocabularyList")
+                .EnumerateArray()
+                .SelectMany(x => JsonMasterdataParser.Create(x, extensions).Parse()));
+        }
+
+        return masterdataList;
     }
 }

--- a/src/FasTnT.Features.v2_0/Communication/Json/Parsers/JsonMasterdataParser.cs
+++ b/src/FasTnT.Features.v2_0/Communication/Json/Parsers/JsonMasterdataParser.cs
@@ -44,7 +44,7 @@ public class JsonMasterdataParser
                 case "attributes":
                     masterdata.Attributes = property.Value.EnumerateArray().Select(ParseVocabularyAttribute).ToList(); break;
                 case "children":
-                    masterdata.Children = element.EnumerateArray().Select(x => new MasterDataChildren { ChildrenId = x.GetString() }).ToList(); break;
+                    masterdata.Children = property.Value.EnumerateArray().Select(x => new MasterDataChildren { ChildrenId = x.GetString() }).ToList(); break;
                 default: 
                     throw new NotImplementedException();
             }

--- a/src/FasTnT.Features.v2_0/Communication/Json/Parsers/JsonMasterdataParser.cs
+++ b/src/FasTnT.Features.v2_0/Communication/Json/Parsers/JsonMasterdataParser.cs
@@ -1,0 +1,99 @@
+﻿using FasTnT.Domain.Model.Events;
+using System.Text.Json;
+
+namespace FasTnT.Features.v2_0.Communication.Json.Parsers;
+
+public class JsonMasterdataParser
+{
+    private readonly JsonElement _element;
+    private readonly Namespaces _extensions;
+
+    private JsonMasterdataParser(JsonElement element, Namespaces extensions)
+    {
+        _element = element;
+        _extensions = extensions;
+    }
+
+    public static JsonMasterdataParser Create(JsonElement element, Namespaces extensions)
+    {
+        if (element.TryGetProperty("@context", out var context))
+        {
+            extensions = extensions.Merge(Namespaces.Parse(context));
+        }
+
+        return new(element, extensions);
+    }
+
+    public IEnumerable<MasterData> Parse()
+    {
+        var type = _element.GetProperty("type").GetString();
+
+        return _element.GetProperty("vocabularyElementList").EnumerateArray().Select(x => ParseVocabularyElement(x, type));
+    }
+
+    private MasterData ParseVocabularyElement(JsonElement element, string type)
+    {
+        var masterdata = new MasterData { Type = type };
+
+        foreach (var property in element.EnumerateObject())
+        {
+            switch (property.Name)
+            {
+                case "id":
+                    masterdata.Id = property.Value.GetString(); break;
+                case "attributes":
+                    masterdata.Attributes = property.Value.EnumerateArray().Select(ParseVocabularyAttribute).ToList(); break;
+                case "children":
+                    masterdata.Children = element.EnumerateArray().Select(x => new MasterDataChildren { ChildrenId = x.GetString() }).ToList(); break;
+                default: 
+                    throw new NotImplementedException();
+            }
+        }
+
+        return masterdata;
+    }
+
+    private MasterDataAttribute ParseVocabularyAttribute(JsonElement element)
+    {
+        return new()
+        {
+            Id = element.GetProperty("id").GetString(),
+            Value = element.GetProperty("attribute").ValueKind == JsonValueKind.Object ? string.Empty : element.GetProperty("attribute").GetString(),
+            Fields = ParseFields(element.GetProperty("attribute"), null, null),
+        };
+    }
+
+    private List<MasterDataField> ParseFields(JsonElement element, string parentName, string parentNamespace)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            return new List<MasterDataField>();
+        }
+
+        var result = new List<MasterDataField>();
+
+        foreach (var property in element.EnumerateObject())
+        {
+            var fieldName = ParseName(property.Name);
+
+            result.AddRange(ParseFields(property.Value, fieldName.Name, fieldName.Namespace));
+            result.Add(new MasterDataField
+            {
+                Value = property.Value.ValueKind == JsonValueKind.Object ? null : property.Value.GetString(),
+                Name = fieldName.Name,
+                Namespace = fieldName.Namespace,
+                ParentName = parentName,
+                ParentNamespace = parentNamespace,
+            });
+        }
+
+        return result;
+    }
+
+    private (string Namespace, string Name) ParseName(string name)
+    {
+        var parts = name.Split(':', 2);
+
+        return (_extensions[parts[0]], parts[1]);
+    }
+}

--- a/src/FasTnT.Features.v2_0/Communication/Json/Parsers/JsonSensorElementParser.cs
+++ b/src/FasTnT.Features.v2_0/Communication/Json/Parsers/JsonSensorElementParser.cs
@@ -6,7 +6,6 @@ namespace FasTnT.Features.v2_0.Communication.Json.Parsers;
 
 internal static class JsonSensorElementParser
 {
-
     public static SensorElement ParseSensorElement(JsonElement element, Namespaces namespaces)
     {
         var sensorElement = new SensorElement();

--- a/src/FasTnT.Features.v2_0/Communication/Xml/Parsers/XmlEpcisDocumentParser.cs
+++ b/src/FasTnT.Features.v2_0/Communication/Xml/Parsers/XmlEpcisDocumentParser.cs
@@ -11,7 +11,7 @@ public static class XmlEpcisDocumentParser
         var request = new Request
         {
             CaptureDate = DateTime.UtcNow,
-            DocumentTime = DateTime.Parse(root.Attribute("creationDate").Value),
+            DocumentTime = DateTime.Parse(root.Attribute("creationDate").Value).ToUniversalTime(),
             SchemaVersion = root.Attribute("schemaVersion").Value
         };
 

--- a/src/FasTnT.Features.v2_0/Communication/Xml/Parsers/XmlMasterdataParser.cs
+++ b/src/FasTnT.Features.v2_0/Communication/Xml/Parsers/XmlMasterdataParser.cs
@@ -1,0 +1,69 @@
+﻿using FasTnT.Domain.Model.Events;
+
+namespace FasTnT.Features.v2_0.Communication.Xml.Parsers;
+
+public static class XmlMasterdataParser
+{
+    public static IEnumerable<MasterData> ParseMasterdata(XElement root)
+    {
+        return root.Elements("Vocabulary").SelectMany(ParseVocabulary);
+    }
+
+    private static IEnumerable<MasterData> ParseVocabulary(XElement element)
+    {
+        var type = element.Attribute("type").Value;
+
+        return element
+            .Element("VocabularyElementList")
+            ?.Elements("VocabularyElement")
+            ?.Select(x => ParseVocabularyElement(x, type));
+    }
+
+    private static MasterData ParseVocabularyElement(XElement element, string type)
+    {
+        return new()
+        {
+            Type = type,
+            Id = element.Attribute("id").Value,
+            Attributes = element.Elements("attribute").Select(ParseVocabularyAttribute).ToList(),
+            Children = ParseChildren(element.Element("children"))
+        };
+    }
+
+    private static List<MasterDataChildren> ParseChildren(XElement element)
+    {
+        return element?.Elements("id")?.Select(x => new MasterDataChildren { ChildrenId = x.Value })?.ToList() ?? new();
+    }
+
+    private static MasterDataAttribute ParseVocabularyAttribute(XElement element)
+    {
+        return new()
+        {
+            Id = element.Attribute("id").Value,
+            Value = element.HasElements ? string.Empty : element.Value,
+            Fields = element.Elements().SelectMany(x => ParseField(x)).ToList()
+        };
+    }
+
+    private static IEnumerable<MasterDataField> ParseField(XElement element, XName parentName = default)
+    {
+        var result = new List<MasterDataField>
+        {
+            new()
+            {
+                Value = element.HasElements ? null : element.Value,
+                Name = element.Name.LocalName,
+                Namespace = element.Name.NamespaceName,
+                ParentName = parentName?.LocalName,
+                ParentNamespace = parentName?.NamespaceName,
+            }
+        };
+
+        if (element.HasElements)
+        {
+            result.AddRange(element.Elements().SelectMany(x => ParseField(x, element.Name)));
+        }
+
+        return result;
+    }
+}

--- a/src/FasTnT.Features.v2_0/Communication/Xml/Parsers/XmlStandardBusinessHeaderParser.cs
+++ b/src/FasTnT.Features.v2_0/Communication/Xml/Parsers/XmlStandardBusinessHeaderParser.cs
@@ -1,0 +1,58 @@
+﻿using FasTnT.Domain.Enumerations;
+using FasTnT.Domain.Model;
+using FasTnT.Domain.Model.Events;
+
+namespace FasTnT.Features.v2_0.Communication.Xml.Parsers;
+
+internal static class XmlStandardBusinessHeaderParser
+{
+    const string Namespace = "http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader";
+    public static StandardBusinessHeader ParseHeader(XElement sbdh)
+    {
+        var documentIdentification = sbdh.Element(XName.Get("DocumentIdentification", Namespace));
+
+        return new()
+        {
+            Version = sbdh.Element(XName.Get("HeaderVersion", Namespace))?.Value,
+            Standard = documentIdentification?.Element(XName.Get("Standard", Namespace))?.Value,
+            TypeVersion = documentIdentification?.Element(XName.Get("TypeVersion", Namespace))?.Value,
+            CreationDateTime = DateTime.TryParse(documentIdentification?.Element(XName.Get("CreationDateAndTime", Namespace))?.Value, out DateTime result) ? result : default,
+            InstanceIdentifier = documentIdentification?.Element(XName.Get("InstanceIdentifier", Namespace))?.Value,
+            Type = documentIdentification?.Element(XName.Get("Type", Namespace))?.Value,
+            ContactInformations = ParseContactInformations(sbdh)
+        };
+    }
+
+    private static List<ContactInformation> ParseContactInformations(XElement sbdh)
+    {
+        var result = new List<ContactInformation>();
+
+        var sender = sbdh.Element(XName.Get("Sender", Namespace));
+        var receiver = sbdh.Element(XName.Get("Receiver", Namespace));
+
+        if (sender != default)
+        {
+            result.Add(ParseContactInformation(sender, ContactInformationType.Sender));
+        }
+        if (receiver != default)
+        {
+            result.Add(ParseContactInformation(receiver, ContactInformationType.Receiver));
+        }
+
+        return result;
+    }
+
+    private static ContactInformation ParseContactInformation(XElement element, ContactInformationType type)
+    {
+        return new()
+        {
+            Type = type,
+            Identifier = element.Element(XName.Get("Identifier", Namespace))?.Value,
+            Contact = element.Element(XName.Get("Contact", Namespace))?.Value,
+            ContactTypeIdentifier = element.Element(XName.Get("ContactTypeIdentifier", Namespace))?.Value,
+            EmailAddress = element.Element(XName.Get("EmailAddress", Namespace))?.Value,
+            FaxNumber = element.Element(XName.Get("FaxNumber", Namespace))?.Value,
+            TelephoneNumber = element.Element(XName.Get("TelephoneNumber", Namespace))?.Value
+        };
+    }
+}

--- a/tests/FasTnT.Features.v2_0.Tests/Communication/Json/WhenParsingARequestContainingEventAndCbvMasterdata.cs
+++ b/tests/FasTnT.Features.v2_0.Tests/Communication/Json/WhenParsingARequestContainingEventAndCbvMasterdata.cs
@@ -1,0 +1,53 @@
+﻿using FasTnT.Domain.Model;
+using FasTnT.Features.v2_0.Communication.Json.Parsers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace FasTnT.Features.v2_0.Tests.Communication.Json;
+
+[TestClass]
+public class WhenParsingARequestContainingEventAndCbvMasterdata : JsonParsingTestCase
+{
+    public static readonly string ResourceName = "FasTnT.Features.v2_0.Tests.Resources.Requests.Request_ObjectEvent_WithMasterdata.json";
+
+    public Request Request { get; set; }
+
+    [TestInitialize]
+    public void When()
+    {
+        Request = JsonEpcisDocumentParser.Parse(ParseResource(ResourceName), TestNamespaces.Default);
+    }
+
+    [TestMethod]
+    public void RequestShouldContainsOneEvent()
+    {
+        Assert.AreEqual(1, Request.Events.Count);
+    }
+
+    [TestMethod]
+    public void RequestShouldContainsOneMasterdata()
+    {
+        Assert.AreEqual(1, Request.Masterdata.Count);
+    }
+
+    [TestMethod]
+    public void ParsedMasterdataShouldMatchTheJsonDocument()
+    {
+        var masterdata = Request.Masterdata.Single();
+
+        Assert.AreEqual("urn:epcglobal:epcis:vtype:ReadPoint", masterdata.Type);
+        Assert.AreEqual("urn:epc:id:sgln:0037000.00729.8000", masterdata.Id);
+        Assert.AreEqual(1, masterdata.Attributes.Count);
+        Assert.AreEqual("urn:epcglobal:cbv:mda:site", masterdata.Attributes.Single().Id);
+        Assert.AreEqual("test", masterdata.Attributes.Single().Value);
+        Assert.AreEqual(0, masterdata.Attributes.Single().Fields.Count);
+    }
+
+    [TestMethod]
+    public void RequestDateShouldBePopulated()
+    {
+        var expectedDate = new DateTime(2013, 06, 04, 12, 59, 02, 099);
+        Assert.AreEqual(expectedDate, Request.DocumentTime);
+    }
+}

--- a/tests/FasTnT.Features.v2_0.Tests/Communication/Json/WhenParsingARequestContainingEventAndMultipleCbvMasterdata.cs
+++ b/tests/FasTnT.Features.v2_0.Tests/Communication/Json/WhenParsingARequestContainingEventAndMultipleCbvMasterdata.cs
@@ -1,0 +1,44 @@
+﻿using FasTnT.Domain.Model;
+using FasTnT.Features.v2_0.Communication.Json.Parsers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace FasTnT.Features.v2_0.Tests.Communication.Json;
+
+[TestClass]
+public class WhenParsingARequestContainingEventAndMultipleCbvMasterdata : JsonParsingTestCase
+{
+    public static readonly string ResourceName = "FasTnT.Features.v2_0.Tests.Resources.Requests.Request_ObjectEvent_WithMultipleMasterdata.json";
+
+    public Request Request { get; set; }
+
+    [TestInitialize]
+    public void When()
+    {
+        Request = JsonEpcisDocumentParser.Parse(ParseResource(ResourceName), TestNamespaces.Default);
+    }
+
+    [TestMethod]
+    public void RequestShouldContainsOneEvent()
+    {
+        Assert.AreEqual(1, Request.Events.Count);
+    }
+
+    [TestMethod]
+    public void RequestShouldContainsAllTheMasterdata()
+    {
+        Assert.AreEqual(3, Request.Masterdata.Count);
+        Assert.AreEqual(2, Request.Masterdata.Count(x => x.Type == "urn:epcglobal:epcis:vtype:ReadPoint"));
+        Assert.AreEqual(1, Request.Masterdata.Count(x => x.Type == "urn:epcglobal:epcis:vtype:BizLocation"));
+        Assert.AreEqual(2, Request.Masterdata.Single(x => x.Type == "urn:epcglobal:epcis:vtype:BizLocation").Attributes.Count);
+        Assert.AreEqual(2, Request.Masterdata.Single(x => x.Type == "urn:epcglobal:epcis:vtype:BizLocation").Children.Count);
+    }
+
+    [TestMethod]
+    public void RequestDateShouldBePopulated()
+    {
+        var expectedDate = new DateTime(2013, 06, 04, 12, 59, 02, 099);
+        Assert.AreEqual(expectedDate, Request.DocumentTime);
+    }
+}

--- a/tests/FasTnT.Features.v2_0.Tests/Communication/XML/WhenParsingARequestContainingEventAndCbvMasterdata.cs
+++ b/tests/FasTnT.Features.v2_0.Tests/Communication/XML/WhenParsingARequestContainingEventAndCbvMasterdata.cs
@@ -1,0 +1,53 @@
+﻿using FasTnT.Domain.Model;
+using FasTnT.Features.v2_0.Communication.Xml.Parsers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace FasTnT.Features.v2_0.Tests.Communication.Xml;
+
+[TestClass]
+public class WhenParsingARequestContainingEventAndCbvMasterdata : XmlParsingTestCase
+{
+    public static readonly string ResourceName = "FasTnT.Features.v2_0.Tests.Resources.Requests.Request_ObjectEvent_WithMasterdata.xml";
+
+    public Request Request { get; set; }
+
+    [TestInitialize]
+    public void When()
+    {
+        Request = XmlEpcisDocumentParser.Parse(ParseResource(ResourceName));
+    }
+
+    [TestMethod]
+    public void RequestShouldContainsOneEvent()
+    {
+        Assert.AreEqual(1, Request.Events.Count);
+    }
+
+    [TestMethod]
+    public void RequestShouldContainsOneMasterdata()
+    {
+        Assert.AreEqual(1, Request.Masterdata.Count);
+    }
+
+    [TestMethod]
+    public void ParsedMasterdataShouldMatchTheJsonDocument()
+    {
+        var masterdata = Request.Masterdata.Single();
+
+        Assert.AreEqual("urn:epcglobal:epcis:vtype:ReadPoint", masterdata.Type);
+        Assert.AreEqual("urn:epc:id:sgln:0037000.00729.8001", masterdata.Id);
+        Assert.AreEqual(1, masterdata.Attributes.Count);
+        Assert.AreEqual("urn:epcglobal:cbv:mda:site", masterdata.Attributes.Single().Id);
+        Assert.AreEqual("0037000007296", masterdata.Attributes.Single().Value);
+        Assert.AreEqual(0, masterdata.Attributes.Single().Fields.Count);
+    }
+
+    [TestMethod]
+    public void RequestDateShouldBePopulated()
+    {
+        var expectedDate = new DateTime(2016, 09, 20, 17, 45, 20, 0);
+        Assert.AreEqual(expectedDate, Request.DocumentTime);
+    }
+}

--- a/tests/FasTnT.Features.v2_0.Tests/Communication/XML/WhenParsingAnObjectEventWithStringCertificationInfo.cs
+++ b/tests/FasTnT.Features.v2_0.Tests/Communication/XML/WhenParsingAnObjectEventWithStringCertificationInfo.cs
@@ -1,5 +1,7 @@
 ﻿using FasTnT.Domain.Model.Events;
+using FasTnT.Features.v2_0.Communication.Json.Parsers;
 using FasTnT.Features.v2_0.Communication.Xml.Parsers;
+using FasTnT.Features.v2_0.Tests.Communication.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace FasTnT.Features.v2_0.Tests.Communication.Xml;

--- a/tests/FasTnT.Features.v2_0.Tests/FasTnT.Features.v2_0.Tests.csproj
+++ b/tests/FasTnT.Features.v2_0.Tests/FasTnT.Features.v2_0.Tests.csproj
@@ -9,9 +9,13 @@
     <None Remove="Resources\Events\ObjectEvent_StringCertificationInfo.xml" />
     <None Remove="Resources\Events\ObjectEvent_StringCertificationInfoArray.json" />
     <None Remove="Resources\Events\ObjectEvent_StringCertificationInfoArrayInvalid.json" />
+    <None Remove="Resources\Events\Request_ObjectEvent_WithMasterdata.json" />
     <None Remove="Resources\Events\TransformationEvent_Full.json" />
+    <None Remove="Resources\Requests\Request_ObjectEvent_WithMasterdata.xml" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Resources\Requests\Request_ObjectEvent_WithMasterdata.xml" />
+    <EmbeddedResource Include="Resources\Requests\Request_ObjectEvent_WithMasterdata.json" />
     <EmbeddedResource Include="Resources\Events\ObjectEvent_StringCertificationInfo.xml" />
     <EmbeddedResource Include="Resources\Events\ObjectEvent_StringCertificationInfoArrayInvalid.json" />
     <EmbeddedResource Include="Resources\Events\ObjectEvent_StringCertificationInfoArray.json" />

--- a/tests/FasTnT.Features.v2_0.Tests/FasTnT.Features.v2_0.Tests.csproj
+++ b/tests/FasTnT.Features.v2_0.Tests/FasTnT.Features.v2_0.Tests.csproj
@@ -12,8 +12,10 @@
     <None Remove="Resources\Events\Request_ObjectEvent_WithMasterdata.json" />
     <None Remove="Resources\Events\TransformationEvent_Full.json" />
     <None Remove="Resources\Requests\Request_ObjectEvent_WithMasterdata.xml" />
+    <None Remove="Resources\Requests\Request_ObjectEvent_WithMultipleMasterdata.json" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Resources\Requests\Request_ObjectEvent_WithMultipleMasterdata.json" />
     <EmbeddedResource Include="Resources\Requests\Request_ObjectEvent_WithMasterdata.xml" />
     <EmbeddedResource Include="Resources\Requests\Request_ObjectEvent_WithMasterdata.json" />
     <EmbeddedResource Include="Resources\Events\ObjectEvent_StringCertificationInfo.xml" />

--- a/tests/FasTnT.Features.v2_0.Tests/Resources/Requests/Request_ObjectEvent_WithMasterdata.json
+++ b/tests/FasTnT.Features.v2_0.Tests/Resources/Requests/Request_ObjectEvent_WithMasterdata.json
@@ -1,0 +1,184 @@
+﻿{
+  "type": "EPCISDocument",
+  "schemaVersion": "2.0",
+  "creationDate": "2013-06-04T14:59:02.099+02:00",
+  "epcisHeader": {
+    "epcisMasterData": {
+      "vocabularyList": [
+        {
+          "type": "urn:epcglobal:epcis:vtype:ReadPoint",
+          "vocabularyElementList": [
+            {
+              "id": "urn:epc:id:sgln:0037000.00729.8000",
+              "attributes": [
+                {
+                  "id": "urn:epcglobal:cbv:mda:site",
+                  "attribute": "test"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "epcisBody": {
+    "eventList": [
+      {
+        "type": "TransformationEvent",
+        "certificationInfo": "test",
+        "eventTime": "2013-10-31T14:58:56.591Z",
+        "eventTimeZoneOffset": "+02:00",
+        "inputEPCList": [
+          "urn:epc:id:sgtin:4012345.011122.25",
+          "urn:epc:id:sgtin:4000001.065432.99886655"
+        ],
+        "inputQuantityList": [
+          {
+            "epcClass": "urn:epc:class:lgtin:4012345.011111.4444",
+            "quantity": 10,
+            "uom": "KGM"
+          },
+          {
+            "epcClass": "urn:epc:class:lgtin:0614141.077777.987",
+            "quantity": 30
+          },
+          {
+            "epcClass": "urn:epc:idpat:sgtin:4012345.066666.*",
+            "quantity": 220
+          }
+        ],
+        "outputEPCList": [
+          "urn:epc:id:sgtin:4012345.077889.25",
+          "urn:epc:id:sgtin:4012345.077889.26",
+          "urn:epc:id:sgtin:4012345.077889.27",
+          "urn:epc:id:sgtin:4012345.077889.28"
+        ],
+        "outputQuantityList": [
+          {
+            "epcClass": "urn:epc:class:lgtin:4012345.011111.4444",
+            "quantity": 10,
+            "uom": "KGM"
+          },
+          {
+            "epcClass": "urn:epc:class:lgtin:0614141.077777.987",
+            "quantity": 30
+          },
+          {
+            "epcClass": "urn:epc:idpat:sgtin:4012345.066666.*",
+            "quantity": 220
+          }
+        ],
+        "transformationID": "urn:epc:id:gdti:0614141.12345.400",
+        "bizStep": "commissioning",
+        "disposition": "in_progress",
+        "readPoint": {
+          "id": "urn:epc:id:sgln:4012345.00001.0"
+        },
+        "bizLocation": {
+          "id": "urn:epc:id:sgln:0614141.00888.0"
+        },
+        "bizTransactionList": [
+          {
+            "type": "po",
+            "bizTransaction": "urn:epc:id:gdti:0614141.00001.1618034"
+          },
+          {
+            "type": "pedigree",
+            "bizTransaction": "urn:epc:id:gsrn:0614141.0000010253"
+          }
+        ],
+        "sourceList": [
+          {
+            "type": "location",
+            "source": "urn:epc:id:sgln:4012345.00225.0"
+          },
+          {
+            "type": "possessing_party",
+            "source": "urn:epc:id:pgln:4012345.00225"
+          },
+          {
+            "type": "owning_party",
+            "source": "urn:epc:id:pgln:4012345.00225"
+          }
+        ],
+        "destinationList": [
+          {
+            "type": "location",
+            "destination": "urn:epc:id:sgln:0614141.00777.0"
+          },
+          {
+            "type": "possessing_party",
+            "destination": "urn:epc:id:pgln:0614141.00777"
+          },
+          {
+            "type": "owning_party",
+            "destination": "urn:epc:id:pgln:0614141.00777"
+          }
+        ],
+        "sensorElementList": [
+          {
+            "type": "epcis:SensorElement",
+            "sensorMetadata": {
+              "time": "2019-04-02T13:05:00.000Z",
+              "deviceID": "urn:epc:id:giai:4000001.111",
+              "deviceMetadata": "https://id.gs1.org/giai/4000001111",
+              "rawData": "https://example.org/giai/401234599999",
+              "startTime": "2019-04-02T12:55:01.000Z",
+              "endTime": "2019-04-02T13:55:00.000Z",
+              "dataProcessingMethod": "https://example.com/gdti/4012345000054987",
+              "bizRules": "https://example.com/gdti/4012345000054987"
+            },
+            "sensorReport": [
+              {
+                "type": "gs1:Temperature",
+                "deviceID": "urn:epc:id:giai:4000001.111",
+                "rawData": "https://example.org/giai/401234599999",
+                "dataProcessingMethod": "https://example.com/gdti/4012345000054987",
+                "time": "2019-07-19T13:00:00.000Z",
+                "microorganism": "https://www.ncbi.nlm.nih.gov/taxonomy/1126011",
+                "chemicalSubstance": "https://identifiers.org/inchikey:CZMRCDWAGMRECN-UGDNZRGBSA-N",
+                "value": 26,
+                "component": "example:x",
+                "stringValue": "SomeString",
+                "booleanValue": true,
+                "hexBinaryValue": "f0f0f0",
+                "uriValue": "https://id.gs1.org/giai/4000001111",
+                "minValue": 26,
+                "maxValue": 26.2,
+                "meanValue": 13.2,
+                "percRank": 50,
+                "percValue": 12.7,
+                "uom": "CEL",
+                "sDev": 0.1,
+                "deviceMetadata": "https://id.gs1.org/giai/4000001111"
+              }
+            ]
+          }
+        ],
+        "persistentDisposition": {
+          "set": [
+            "completeness_verified",
+            "test",
+            "toto"
+          ],
+          "unset": [
+            "completeness_inferred"
+          ]
+        }
+      }
+    ]
+  },
+  "@context": [
+    "https://gs1.github.io/EPCIS/epcis-context.jsonld",
+    {
+      "ext3": "http://example.com/ext3/"
+    },
+    {
+      "ext2": "http://example.com/ext2/"
+    },
+    {
+      "ext1": "http://example.com/ext1/"
+    }
+  ]
+}

--- a/tests/FasTnT.Features.v2_0.Tests/Resources/Requests/Request_ObjectEvent_WithMasterdata.xml
+++ b/tests/FasTnT.Features.v2_0.Tests/Resources/Requests/Request_ObjectEvent_WithMasterdata.xml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<epcis:EPCISDocument xmlns:cbvmda="urn:epcglobal:cbv:mda" xmlns:epcis="urn:epcglobal:epcis:xsd:2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wg4="http://epcis.wg4.fr/ns" xmlns:sbdh="http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader" schemaVersion="2.0" creationDate="2016-09-20T17:45:20.0Z">
+  <EPCISHeader>
+    <extension>
+      <EPCISMasterData>
+        <VocabularyList>
+          <Vocabulary type="urn:epcglobal:epcis:vtype:ReadPoint">
+           <VocabularyElementList>
+            <VocabularyElement id="urn:epc:id:sgln:0037000.00729.8001">
+             <attribute id="urn:epcglobal:cbv:mda:site">0037000007296</attribute>
+            </VocabularyElement>
+           </VocabularyElementList>
+         </Vocabulary>
+        </VocabularyList>
+      </EPCISMasterData>
+    </extension>
+  </EPCISHeader>
+  <EPCISBody>
+    <EventList>
+      <ObjectEvent>
+        <eventTime>2012-04-05T11:35:00.000Z</eventTime>
+        <eventTimeZoneOffset>+01:00</eventTimeZoneOffset>
+        <epcList>
+        </epcList>
+        <action>ADD</action>
+        <bizStep>urn:epcglobal:cbv:bizstep:commissioning</bizStep>
+        <disposition>urn:epcglobal:cbv:disp:active</disposition>
+        <bizLocation>
+          <id>urn:epc:id:sgln:409876.500001.0</id>
+        </bizLocation>
+      </ObjectEvent>
+    </EventList>
+  </EPCISBody>
+</epcis:EPCISDocument>

--- a/tests/FasTnT.Features.v2_0.Tests/Resources/Requests/Request_ObjectEvent_WithMultipleMasterdata.json
+++ b/tests/FasTnT.Features.v2_0.Tests/Resources/Requests/Request_ObjectEvent_WithMultipleMasterdata.json
@@ -1,0 +1,67 @@
+﻿{
+  "type": "EPCISDocument",
+  "schemaVersion": "2.0",
+  "creationDate": "2013-06-04T14:59:02.099+02:00",
+  "epcisHeader": {
+    "epcisMasterData": {
+      "vocabularyList": [
+        {
+          "type": "urn:epcglobal:epcis:vtype:ReadPoint",
+          "vocabularyElementList": [
+            {
+              "id": "urn:epc:id:sgln:0037000.00729.8000",
+              "attributes": [
+                {
+                  "id": "urn:epcglobal:cbv:mda:site",
+                  "attribute": "test"
+                }
+              ]
+            },
+            {
+              "id": "urn:epc:id:sgln:0037000.00729.8002",
+              "attributes": [
+                {
+                  "id": "urn:epcglobal:cbv:mda:site",
+                  "attribute": "5020039502"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "urn:epcglobal:epcis:vtype:BizLocation",
+          "vocabularyElementList": [
+            {
+              "id": "urn:epc:id:sgln:0054321.00729",
+              "attributes": [
+                {
+                  "id": "urn:epcglobal:cbv:mda:wh",
+                  "attribute": "WH01"
+                },
+                {
+                  "id": "internalid",
+                  "attribute": "WH01.52/0"
+                }
+              ],
+              "children": [ "urn:epc:id:sgln:0054321.00730", "urn:epc:id:sgln:0054321.00731" ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "epcisBody": {
+    "eventList": [
+      {
+        "type": "ObjectEvent",
+        "action": "OBSERVE",
+        "bizStep": "inspecting",
+        "disposition": "active",
+        "epcList": [ "urn:epc:id:sscc:4001356.5900000817" ],
+        "eventTime": "2021-02-15T14:00:00Z",
+        "eventTimeZoneOffset": "-06:00"
+      }
+    ]
+  },
+  "@context": [ "https://gs1.github.io/EPCIS/epcis-context.jsonld" ]
+}


### PR DESCRIPTION
Add XML and JSON parsers for CBV Masterdata in v2.0 endpoints, and closes #254  

Note that the EPCIS 2.0 specification removes any reference to the SimpleMasterdataQuery, so the masterdata is stored but can't be retrieved except by using the v1.2 SOAP query.