### PR TITLE
#470 Fix fields names in EF Core model configuration

### DIFF
--- a/src/FasTnT.Application/Database/EpcisModelConfiguration.cs
+++ b/src/FasTnT.Application/Database/EpcisModelConfiguration.cs
@@ -77,7 +77,7 @@ public static class EpcisModelConfiguration
         masterData.Property(x => x.Type).HasMaxLength(256).IsRequired(true);
         masterData.Property(x => x.Id).HasMaxLength(256).IsRequired(true);
         masterData.HasMany(x => x.Attributes).WithOne(x => x.MasterData).HasForeignKey("RequestId", "MasterdataType", "MasterdataId");
-        masterData.HasMany(x => x.Children).WithOne(x => x.MasterData).HasForeignKey("MasterDataRequestId", "MasterdataType", "MasterdataId");
+        masterData.HasMany(x => x.Children).WithOne(x => x.MasterData).HasForeignKey("MasterDataRequestId", "MasterDataType", "MasterDataId");
 
         var mdAttribute = modelBuilder.Entity<MasterDataAttribute>();
         mdAttribute.ToTable(nameof(MasterDataAttribute), Cbv);


### PR DESCRIPTION
Fix casing for MasterData - MasterDataChildren relationship in EF Core model configuration.