### PR TITLE
Use constant parameters to query events

### DIFF
--- a/src/FasTnT.Application/Database/DataSources/Utils/QueryParameterExtensions.cs
+++ b/src/FasTnT.Application/Database/DataSources/Utils/QueryParameterExtensions.cs
@@ -79,4 +79,13 @@ internal static class QueryParameterExtensions
     {
         return Expression.Lambda<Func<T, bool>>(Expression.OrElse(expr1.Body, Expression.Invoke(expr2, expr1.Parameters[0])), expr1.Parameters[0]);
     }
+    internal static IQueryable<TQuery> WhereIn<TQuery, TKey>(this IQueryable<TQuery> queryable, Expression<Func<TQuery, TKey>> keySelector, IEnumerable<TKey> values)
+    {
+        var method = values.GetType().GetMethod("Contains");
+        var instance = Expression.Constant(values);
+        var expression = Expression.Call(instance, method, keySelector.Body);
+        var lambda = Expression.Lambda<Func<TQuery, bool>>(expression, keySelector.Parameters);
+
+        return queryable.Where(lambda);
+    }
 }

--- a/src/FasTnT.Application/Database/EpcisContext.cs
+++ b/src/FasTnT.Application/Database/EpcisContext.cs
@@ -11,7 +11,7 @@ public class EpcisContext : DbContext
 {
     public EpcisContext(DbContextOptions<EpcisContext> options) : base(options)
     {
-        ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking; 
+        ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
     }
 
     public IQueryable<Event> QueryEvents(IEnumerable<QueryParameter> parameters)


### PR DESCRIPTION
Instead of specifying the event IDs as SQL parameters, use a constant expression instead.

The generated EF query changes from `WHERE eventid = @p01 OR eventid = @p02 ...` to `WHERE eventid IN (1,2,...)`

This seems safe as the event IDs are directly retrieved from the database without modification