### PR TITLE
EPCIS 1.2 Query param filter fix

### DIFF
--- a/src/FasTnT.Application/Database/DataSources/EventQueryContext.cs
+++ b/src/FasTnT.Application/Database/DataSources/EventQueryContext.cs
@@ -140,11 +140,11 @@ internal sealed class EventQueryContext
             case var s when s.StartsWith("MATCH_"):
                 ApplyMatchParameter(param); break;
             case var s when s.StartsWith("EQ_source_"):
-                Filter(x => x.Sources.Any(s => s.Id == param.GetSimpleId() && param.Values.Contains(s.Type))); break;
+                Filter(x => x.Sources.Any(s => s.Type == param.GetSimpleId() && param.Values.Contains(s.Id))); break;
             case var s when s.StartsWith("EQ_destination_"):
-                Filter(x => x.Destinations.Any(d => d.Id == param.GetSimpleId() && param.Values.Contains(d.Type))); break;
+                Filter(x => x.Destinations.Any(d => d.Type == param.GetSimpleId() && param.Values.Contains(d.Id))); break;
             case var s when s.StartsWith("EQ_bizTransaction_"):
-                Filter(x => x.Transactions.Any(t => t.Id == param.GetSimpleId() && param.Values.Contains(t.Type))); break;
+                Filter(x => x.Transactions.Any(t => t.Type == param.GetSimpleId() && param.Values.Contains(t.Id))); break;
             case var s when s.StartsWith("EQ_INNER_ILMD_"):
                 ApplyFieldParameter(FieldType.Ilmd, true, param.InnerIlmdName(), param.InnerIlmdNamespace(), param.Values); break;
             case var s when s.StartsWith("EQ_ILMD_"):

--- a/src/FasTnT.Application/Database/DataSources/EventQueryContext.cs
+++ b/src/FasTnT.Application/Database/DataSources/EventQueryContext.cs
@@ -140,11 +140,11 @@ internal sealed class EventQueryContext
             case var s when s.StartsWith("MATCH_"):
                 ApplyMatchParameter(param); break;
             case var s when s.StartsWith("EQ_source_"):
-                Filter(x => x.Sources.Any(s => s.Type == param.GetSimpleId() && param.Values.Contains(s.Id))); break;
+                Filter(x => x.Sources.Any(s => s.Type == param.GetSimpleType() && param.Values.Contains(s.Id))); break;
             case var s when s.StartsWith("EQ_destination_"):
-                Filter(x => x.Destinations.Any(d => d.Type == param.GetSimpleId() && param.Values.Contains(d.Id))); break;
+                Filter(x => x.Destinations.Any(d => d.Type == param.GetSimpleType() && param.Values.Contains(d.Id))); break;
             case var s when s.StartsWith("EQ_bizTransaction_"):
-                Filter(x => x.Transactions.Any(t => t.Type == param.GetSimpleId() && param.Values.Contains(t.Id))); break;
+                Filter(x => x.Transactions.Any(t => t.Type == param.GetSimpleType() && param.Values.Contains(t.Id))); break;
             case var s when s.StartsWith("EQ_INNER_ILMD_"):
                 ApplyFieldParameter(FieldType.Ilmd, true, param.InnerIlmdName(), param.InnerIlmdNamespace(), param.Values); break;
             case var s when s.StartsWith("EQ_ILMD_"):

--- a/src/FasTnT.Application/Database/DataSources/Utils/QueryParameterExtensions.cs
+++ b/src/FasTnT.Application/Database/DataSources/Utils/QueryParameterExtensions.cs
@@ -27,7 +27,7 @@ internal static class QueryParameterExtensions
         return parameter.Values[0];
     }
 
-    public static string GetSimpleId(this QueryParameter parameter) => parameter.Name.Split('_', 3)[2]; // Consider renaming, something like GetSimpleType?
+    public static string GetSimpleType(this QueryParameter parameter) => parameter.Name.Split('_', 3)[2];
     public static string InnerIlmdName(this QueryParameter parameter) => parameter.Name.Split('_')[3].Split('#')[1];
     public static string InnerIlmdNamespace(this QueryParameter parameter) => parameter.Name.Split('_')[3].Split('#')[0];
     public static string IlmdName(this QueryParameter parameter) => parameter.Name.Split('_')[2].Split('#')[1];

--- a/src/FasTnT.Application/Database/DataSources/Utils/QueryParameterExtensions.cs
+++ b/src/FasTnT.Application/Database/DataSources/Utils/QueryParameterExtensions.cs
@@ -27,7 +27,7 @@ internal static class QueryParameterExtensions
         return parameter.Values[0];
     }
 
-    public static string GetSimpleId(this QueryParameter parameter) => parameter.Name.Split('_', 3)[2];
+    public static string GetSimpleId(this QueryParameter parameter) => parameter.Name.Split('_', 3)[2]; // Consider renaming, something like GetSimpleType?
     public static string InnerIlmdName(this QueryParameter parameter) => parameter.Name.Split('_')[3].Split('#')[1];
     public static string InnerIlmdNamespace(this QueryParameter parameter) => parameter.Name.Split('_')[3].Split('#')[0];
     public static string IlmdName(this QueryParameter parameter) => parameter.Name.Split('_')[2].Split('#')[1];


### PR DESCRIPTION
Fix: Correct filter logic for EQ_bizTransaction_type, EQ_source_type, and EQ_destination_type params in EventQueryContext.

Now compares Type to GetSimpleId() and value to Id, matching EPCIS 1.2 query semantics. Prevents filtering out valid events when querying by business transaction, source, or destination.

Suggest name change for GetSimpleId() -> GetSimpleType()